### PR TITLE
feat: Unity Code Coverageサポートを追加

### DIFF
--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -159,29 +159,49 @@ jobs:
         echo "=== Coverage directory structure ==="
         ls -la CodeCoverage/ 2>/dev/null || echo "CodeCoverage directory not found"
         
-        coverage_file="CodeCoverage/Report/Summary.xml"
-        # 他の可能なパスも試す
-        if [ ! -f "$coverage_file" ]; then
-          coverage_file=$(find CodeCoverage -name "Summary.xml" -type f | head -1)
+        # Unity Code CoverageはOpenCover形式のXMLを生成
+        # TestCoverageResults_*.xmlファイルを探す
+        coverage_file=$(find CodeCoverage -name "TestCoverageResults_*.xml" -type f | head -1)
+        
+        # ファイルが見つからない場合、Summary.xmlを探す
+        if [ -z "$coverage_file" ] || [ ! -f "$coverage_file" ]; then
+          coverage_file="CodeCoverage/Report/Summary.xml"
         fi
-        if [ ! -f "$coverage_file" ]; then
-          coverage_file=$(find . -name "*TestCoverageResults*.xml" -type f | head -1)
-        fi
+        
+        echo "Looking for coverage file: $coverage_file"
         
         if [ -f "$coverage_file" ]; then
           echo "### Code Coverage Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Coverage report found at: $coverage_file" >> $GITHUB_STEP_SUMMARY
+          echo "📁 Coverage file: \`$coverage_file\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           
           # XMLからカバレッジ情報を抽出
           if command -v xmllint &> /dev/null; then
-            line_coverage=$(xmllint --xpath "string(//CoverageSession/Summary/@sequenceCoverage)" "$coverage_file" 2>/dev/null || echo "0")
-            branch_coverage=$(xmllint --xpath "string(//CoverageSession/Summary/@branchCoverage)" "$coverage_file" 2>/dev/null || echo "0")
+            # 名前空間を無視してXPathを使用
+            line_coverage=$(xmllint --xpath "string(//*[local-name()='CoverageSession']/*[local-name()='Summary']/@sequenceCoverage)" "$coverage_file" 2>/dev/null || echo "")
+            branch_coverage=$(xmllint --xpath "string(//*[local-name()='CoverageSession']/*[local-name()='Summary']/@branchCoverage)" "$coverage_file" 2>/dev/null || echo "")
             
-            # パーセンテージに変換（0-1の値を0-100に）
-            line_percent=$(echo "scale=1; $line_coverage * 100" | bc 2>/dev/null || echo "0")
-            branch_percent=$(echo "scale=1; $branch_coverage * 100" | bc 2>/dev/null || echo "0")
+            # 値が取得できない場合のデバッグ
+            if [ -z "$line_coverage" ]; then
+              echo "⚠️ Debug: Could not find coverage attributes" >> $GITHUB_STEP_SUMMARY
+              echo "<details><summary>XML structure (first 30 lines)</summary>" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "\`\`\`xml" >> $GITHUB_STEP_SUMMARY
+              xmllint --format "$coverage_file" 2>/dev/null | head -30 >> $GITHUB_STEP_SUMMARY || echo "Could not display XML" >> $GITHUB_STEP_SUMMARY
+              echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+              echo "</details>" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              line_coverage="0"
+            fi
+            
+            if [ -z "$branch_coverage" ]; then
+              branch_coverage="0"
+            fi
+            
+            # Unity Code Coverageは既にパーセンテージ形式なのでそのまま使用
+            line_percent=$line_coverage
+            branch_percent=$branch_coverage
             
             echo "📋 **Coverage Results:**" >> $GITHUB_STEP_SUMMARY
             echo "- **Line Coverage**: $line_percent%" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -39,7 +39,7 @@ jobs:
         unityVersion: 6000.0.35f1
         testMode: all
         artifactsPath: test-results
-        coverageOptions: 'generateAdditionalMetrics;generateHtmlReport;generateBadgeReport'
+        coverageOptions: 'generateAdditionalMetrics;generateHtmlReport;generateBadgeReport;assemblyFilters:+uPiper.Runtime,+uPiper.Scripts.Runtime,-uPiper.Tests.*'
         
     # テスト結果をJUnit形式で保存
     - name: Upload Test Results
@@ -140,3 +140,47 @@ jobs:
         path: |
           test-results/CodeCoverage/**
         retention-days: 7
+    
+    # コードカバレッジチェック
+    - name: Check Code Coverage
+      if: always()
+      run: |
+        # カバレッジサマリーファイルを探す
+        coverage_file="test-results/CodeCoverage/Report/Summary.xml"
+        if [ -f "$coverage_file" ]; then
+          echo "### Code Coverage Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          
+          # XMLからカバレッジ情報を抽出
+          if command -v xmllint &> /dev/null; then
+            line_coverage=$(xmllint --xpath "string(//CoverageSession/Summary/@sequenceCoverage)" "$coverage_file" 2>/dev/null || echo "0")
+            branch_coverage=$(xmllint --xpath "string(//CoverageSession/Summary/@branchCoverage)" "$coverage_file" 2>/dev/null || echo "0")
+            
+            # パーセンテージに変換（0-1の値を0-100に）
+            line_percent=$(echo "scale=1; $line_coverage * 100" | bc 2>/dev/null || echo "0")
+            branch_percent=$(echo "scale=1; $branch_coverage * 100" | bc 2>/dev/null || echo "0")
+            
+            echo "- Line Coverage: $line_percent%" >> $GITHUB_STEP_SUMMARY
+            echo "- Branch Coverage: $branch_percent%" >> $GITHUB_STEP_SUMMARY
+            
+            # カバレッジバッジデータを環境変数に保存
+            echo "LINE_COVERAGE=$line_percent" >> $GITHUB_ENV
+            echo "BRANCH_COVERAGE=$branch_percent" >> $GITHUB_ENV
+          else
+            echo "xmllint not available, skipping coverage parsing" >> $GITHUB_STEP_SUMMARY
+          fi
+        else
+          echo "Coverage report not found at: $coverage_file" >> $GITHUB_STEP_SUMMARY
+        fi
+        
+    # Codecovにカバレッジをアップロード
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      if: always()
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        directory: test-results/CodeCoverage
+        files: '**/Summary.xml'
+        flags: unittests
+        name: uPiper
+        fail_ci_if_error: false

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -39,7 +39,8 @@ jobs:
         unityVersion: 6000.0.35f1
         testMode: all
         artifactsPath: test-results
-        coverageOptions: 'generateAdditionalMetrics;generateHtmlReport;generateBadgeReport;assemblyFilters:+uPiper.Runtime,+uPiper.Scripts.Runtime,-uPiper.Tests.*'
+        coverageOptions: 'generateAdditionalMetrics;generateHtmlReport;generateBadgeReport;assemblyFilters:+uPiper.Runtime,+uPiper.Scripts.Runtime,-uPiper.Tests*'
+        customParameters: '-enableCodeCoverage'
         
     # テスト結果をJUnit形式で保存
     - name: Upload Test Results
@@ -146,7 +147,18 @@ jobs:
       if: always()
       run: |
         # カバレッジサマリーファイルを探す
+        echo "=== Looking for coverage files ==="
+        find test-results -name "*.xml" -type f | grep -i coverage || echo "No coverage files found"
+        
         coverage_file="test-results/CodeCoverage/Report/Summary.xml"
+        # 他の可能なパスも試す
+        if [ ! -f "$coverage_file" ]; then
+          coverage_file=$(find test-results -name "Summary.xml" -type f | head -1)
+        fi
+        if [ ! -f "$coverage_file" ]; then
+          coverage_file=$(find test-results -name "*coverage*.xml" -type f | head -1)
+        fi
+        
         if [ -f "$coverage_file" ]; then
           echo "### Code Coverage Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -142,6 +142,13 @@ jobs:
           CodeCoverage/**
         retention-days: 7
     
+    # XMLパース用ツールをインストール
+    - name: Install XML tools
+      if: always()
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libxml2-utils bc
+        
     # コードカバレッジチェック
     - name: Check Code Coverage
       if: always()
@@ -164,6 +171,8 @@ jobs:
         if [ -f "$coverage_file" ]; then
           echo "### Code Coverage Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Coverage report found at: $coverage_file" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
           
           # XMLからカバレッジ情報を抽出
           if command -v xmllint &> /dev/null; then
@@ -174,17 +183,31 @@ jobs:
             line_percent=$(echo "scale=1; $line_coverage * 100" | bc 2>/dev/null || echo "0")
             branch_percent=$(echo "scale=1; $branch_coverage * 100" | bc 2>/dev/null || echo "0")
             
-            echo "- Line Coverage: $line_percent%" >> $GITHUB_STEP_SUMMARY
-            echo "- Branch Coverage: $branch_percent%" >> $GITHUB_STEP_SUMMARY
+            echo "📋 **Coverage Results:**" >> $GITHUB_STEP_SUMMARY
+            echo "- **Line Coverage**: $line_percent%" >> $GITHUB_STEP_SUMMARY
+            echo "- **Branch Coverage**: $branch_percent%" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            
+            # カバレッジが低い場合の警告
+            if (( $(echo "$line_percent < 50" | bc -l) )); then
+              echo "⚠️ **Warning**: Line coverage is below 50%" >> $GITHUB_STEP_SUMMARY
+            fi
             
             # カバレッジバッジデータを環境変数に保存
             echo "LINE_COVERAGE=$line_percent" >> $GITHUB_ENV
             echo "BRANCH_COVERAGE=$branch_percent" >> $GITHUB_ENV
           else
-            echo "xmllint not available, skipping coverage parsing" >> $GITHUB_STEP_SUMMARY
+            echo "❌ **Error**: xmllint not available, cannot parse coverage data" >> $GITHUB_STEP_SUMMARY
+            echo "Please check if XML tools are properly installed" >> $GITHUB_STEP_SUMMARY
           fi
         else
-          echo "Coverage report not found at: $coverage_file" >> $GITHUB_STEP_SUMMARY
+          echo "❌ **Error**: Coverage report not found" >> $GITHUB_STEP_SUMMARY
+          echo "Expected location: $coverage_file" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Available coverage files:" >> $GITHUB_STEP_SUMMARY
+          find . -name "*coverage*.xml" -o -name "*Coverage*.xml" | head -10 | while read f; do
+            echo "- $f" >> $GITHUB_STEP_SUMMARY
+          done
         fi
         
     # Codecovにカバレッジをアップロード

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -139,7 +139,7 @@ jobs:
       with:
         name: Coverage Report
         path: |
-          test-results/CodeCoverage/**
+          CodeCoverage/**
         retention-days: 7
     
     # コードカバレッジチェック
@@ -148,15 +148,17 @@ jobs:
       run: |
         # カバレッジサマリーファイルを探す
         echo "=== Looking for coverage files ==="
-        find test-results -name "*.xml" -type f | grep -i coverage || echo "No coverage files found"
+        find . -name "*.xml" -type f | grep -i coverage || echo "No coverage files found"
+        echo "=== Coverage directory structure ==="
+        ls -la CodeCoverage/ 2>/dev/null || echo "CodeCoverage directory not found"
         
-        coverage_file="test-results/CodeCoverage/Report/Summary.xml"
+        coverage_file="CodeCoverage/Report/Summary.xml"
         # 他の可能なパスも試す
         if [ ! -f "$coverage_file" ]; then
-          coverage_file=$(find test-results -name "Summary.xml" -type f | head -1)
+          coverage_file=$(find CodeCoverage -name "Summary.xml" -type f | head -1)
         fi
         if [ ! -f "$coverage_file" ]; then
-          coverage_file=$(find test-results -name "*coverage*.xml" -type f | head -1)
+          coverage_file=$(find . -name "*TestCoverageResults*.xml" -type f | head -1)
         fi
         
         if [ -f "$coverage_file" ]; then
@@ -191,8 +193,8 @@ jobs:
       if: always()
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        directory: test-results/CodeCoverage
-        files: '**/Summary.xml'
+        directory: ./
+        files: 'CodeCoverage/**/*.xml'
         flags: unittests
         name: uPiper
         fail_ci_if_error: false

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -11,6 +11,7 @@
     "com.unity.multiplayer.center": "1.0.0",
     "com.unity.render-pipelines.universal": "17.0.3",
     "com.unity.test-framework": "1.4.5",
+    "com.unity.testtools.codecoverage": "1.2.6",
     "com.unity.timeline": "1.8.7",
     "com.unity.ugui": "2.0.0",
     "com.unity.visualscripting": "1.9.5",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -260,6 +260,13 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
+    "com.unity.settings-manager": {
+      "version": "2.0.1",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
     "com.unity.shadergraph": {
       "version": "17.0.3",
       "depth": 1,
@@ -287,6 +294,16 @@
       "dependencies": {
         "com.unity.test-framework": "1.1.31",
         "com.unity.modules.jsonserialize": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.testtools.codecoverage": {
+      "version": "1.2.6",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.test-framework": "1.0.16",
+        "com.unity.settings-manager": "1.0.1"
       },
       "url": "https://packages.unity.com"
     },

--- a/ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json
+++ b/ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json
@@ -1,0 +1,48 @@
+{
+    "m_Name": "Settings",
+    "m_Path": "ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json",
+    "m_Dictionary": {
+        "m_DictionaryValues": [
+            {
+                "type": "System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                "key": "Path",
+                "value": "{\"m_Value\":\"{ProjectPath}\"}"
+            },
+            {
+                "type": "System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                "key": "HistoryPath",
+                "value": "{\"m_Value\":\"{ProjectPath}\"}"
+            },
+            {
+                "type": "System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                "key": "IncludeAssemblies",
+                "value": "{\"m_Value\":\"uPiper.Runtime,uPiper.Scripts.Runtime\"}"
+            },
+            {
+                "type": "System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                "key": "ExcludeAssemblies",
+                "value": "{\"m_Value\":\"uPiper.Tests.*,uPiper.Editor\"}"
+            },
+            {
+                "type": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                "key": "AutoGenerateReport",
+                "value": "{\"m_Value\":true}"
+            },
+            {
+                "type": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                "key": "GenerateHtmlReport",
+                "value": "{\"m_Value\":true}"
+            },
+            {
+                "type": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                "key": "GenerateBadgeReport",
+                "value": "{\"m_Value\":true}"
+            },
+            {
+                "type": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                "key": "GenerateAdditionalMetrics",
+                "value": "{\"m_Value\":true}"
+            }
+        ]
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # uPiper
+
+[![Unity Tests](https://github.com/ayutaz/uPiper/actions/workflows/unity-tests.yml/badge.svg)](https://github.com/ayutaz/uPiper/actions/workflows/unity-tests.yml)
+[![codecov](https://codecov.io/gh/ayutaz/uPiper/branch/main/graph/badge.svg?token=YOUR_TOKEN)](https://codecov.io/gh/ayutaz/uPiper)
+
 [piper-plus]()のUnityプラグイン
 
 # requirements


### PR DESCRIPTION
## 概要
Unity Code Coverageパッケージを導入し、テストカバレッジの計測とレポート生成を可能にしました。

## 変更内容

### 1. Unity Code Coverageパッケージの追加
-  v1.2.6をPackages/manifest.jsonに追加
- Unity 2019.3以降で利用可能なパッケージです

### 2. CI/CDでのカバレッジレポート生成
- Unity Test Runnerでカバレッジオプションを設定
- アセンブリフィルタでテストコードを除外（）
- カバレッジレポートをアーティファクトとして保存

### 3. カバレッジ情報の可視化
- CIでカバレッジパーセンテージを計算・表示
- GitHub Step Summaryにカバレッジ情報を追加
- XMLからline coverageとbranch coverageを抽出

### 4. Codecov統合
- CodecovへのカバレッジアップロードをCIに追加
- READMEにカバレッジバッジを追加（設定待ち）

## 必要な設定

### Codecovの設定
1. [Codecov](https://codecov.io/)でリポジトリを登録
2. トークンを取得
3. GitHubリポジトリのSecretsにを追加
4. READMEのバッジURLを更新

### Unity Editorでの設定
1. Window > General > Test Runner > Code Coverage
2. Enable Code Coverageをチェック
3. Generate HTMLレポートをチェック（オプション）

## テスト方法
- CIが自動的にテストを実行し、カバレッジレポートを生成します
- カバレッジレポートは"Coverage Report"アーティファクトとして保存されます
- Codecov設定後は、カバレッジバッジが自動更新されます

## 関連Issue
なし

🤖 Generated with [Claude Code](https://claude.ai/code)