### PR TITLE
fix: Codecovの設定を修正

### DIFF
--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -232,7 +232,7 @@ jobs:
         
     # Codecovにカバレッジをアップロード
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       if: always()
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -241,3 +241,4 @@ jobs:
         flags: unittests
         name: uPiper
         fail_ci_if_error: false
+        verbose: true

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Unity Tests](https://github.com/ayutaz/uPiper/actions/workflows/unity-tests.yml/badge.svg)](https://github.com/ayutaz/uPiper/actions/workflows/unity-tests.yml)
 [![Unity Build](https://github.com/ayutaz/uPiper/actions/workflows/unity-build.yml/badge.svg)](https://github.com/ayutaz/uPiper/actions/workflows/unity-build.yml)
-[![codecov](https://codecov.io/gh/ayutaz/uPiper/branch/main/graph/badge.svg?token=YOUR_TOKEN)](https://codecov.io/gh/ayutaz/uPiper)
+[![codecov](https://codecov.io/github/ayutaz/uPiper/graph/badge.svg?token=348eb741-4320-4368-89fa-3eee5188bd3f)](https://codecov.io/github/ayutaz/uPiper)
 
 [piper-plus]()のUnityプラグイン
 


### PR DESCRIPTION
- READMEのCodecovバッジに正しいトークンを設定
- codecov-action@v3からv5にアップグレード
- verboseオプションを追加してデバッグ情報を出力