### PR TITLE
chore(deps): GitHub Actions依存関係の更新

### DIFF
--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Get changed files
       if: github.event_name == 'pull_request' && github.event.inputs.check_all != 'true'
       id: changed-files
-      uses: tj-actions/changed-files@v44
+      uses: tj-actions/changed-files@v46
       with:
         files: |
           **/*.cs

--- a/.github/workflows/locale-tests.yml
+++ b/.github/workflows/locale-tests.yml
@@ -66,7 +66,7 @@ jobs:
       shell: powershell
         
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.9'
         

--- a/.github/workflows/native-tests.yml
+++ b/.github/workflows/native-tests.yml
@@ -21,7 +21,7 @@ jobs:
         lfs: true
         
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.9'
         

--- a/.github/workflows/performance-regression.yml
+++ b/.github/workflows/performance-regression.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         lfs: true
         
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.9'
         

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -35,7 +35,7 @@ jobs:
         lfs: true
         
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.9'
         
@@ -390,7 +390,7 @@ jobs:
         lfs: true
         
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.9'
         
@@ -455,7 +455,7 @@ jobs:
         lfs: true
         
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.9'
         


### PR DESCRIPTION
## 概要
Dependabotからの提案に基づき、GitHub Actionsの依存関係を更新しました。

## 更新内容
### 1. tj-actions/changed-files: v44 → v46
- 更新ファイル: `.github/workflows/dotnet-format.yml`
- 主な変更点:
  - `modified_keys`と`changed_key`出力のバグ修正
  - 依存関係の更新（yaml, TypeScript, ESLintプラグインなど）
  - Node.jsランタイムの改善

### 2. actions/setup-python: v4 → v5
- 更新ファイル:
  - `.github/workflows/performance-regression.yml`
  - `.github/workflows/native-tests.yml`
  - `.github/workflows/unity-tests.yml` (3箇所)
  - `.github/workflows/locale-tests.yml`
- 主な変更点:
  - Node.jsランタイムをv16からv20へアップグレード
  - `.tool-versions`ファイルのサポート追加
  - Free-threaded Pythonバージョン（3.13tなど）のサポート
  - 依存関係の最新化

## テスト計画
- [x] 各ワークフローファイルの構文確認
- [ ] CI/CDパイプラインの正常動作確認
- [ ] 既存のPRでのワークフロー実行確認

## 関連PR
- #29: tj-actions/changed-files更新のDependabot PR
- #26: actions/setup-python更新のDependabot PR

🤖 Generated with Claude Code