### PR TITLE
feat: GitHubスポンサーボタンを追加

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,13 @@
+# These are supported funding model platforms
+
+github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: # Replace with a single Ko-fi username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+otechie: # Replace with a single Otechie username
+lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,13 +1,3 @@
 # These are supported funding model platforms
 
-github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
-patreon: # Replace with a single Patreon username
-open_collective: # Replace with a single Open Collective username
-ko_fi: # Replace with a single Ko-fi username
-tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
-community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
-liberapay: # Replace with a single Liberapay username
-issuehunt: # Replace with a single IssueHunt username
-otechie: # Replace with a single Otechie username
-lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
-custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']
+github: ayutaz


### PR DESCRIPTION
## 概要
GitHubリポジトリにスポンサーボタンを表示するための設定を追加しました。

## 変更内容
- `.github/FUNDING.yml` ファイルを作成
- スポンサープラットフォームのテンプレートを追加

## 今後の作業
FUNDING.ymlファイルには現在テンプレートのみが含まれています。実際に使用するスポンサープラットフォームの情報を追加してください：

- `github`: GitHub Sponsorsのユーザー名（最大4つ）
- `patreon`: Patreonのユーザー名
- `ko_fi`: Ko-fiのユーザー名
- `custom`: カスタムスポンサーリンク（最大4つ）

など、必要に応じて設定してください。

## テストプラン
- [ ] PRマージ後、リポジトリのメインページにスポンサーボタンが表示されることを確認
- [ ] 設定したスポンサーリンクが正しく機能することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)