### PR TITLE
fix: GitHubスポンサーボタンが表示されない問題を修正

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,3 @@
 # These are supported funding model platforms
 
-github: ayutaz
+github: [ayutaz]


### PR DESCRIPTION
## 概要
GitHubスポンサーボタンが表示されない問題を修正しました。

## 変更内容
- FUNDING.ymlのGitHubユーザー名を配列形式（`[ayutaz]`）に変更
- GitHubの仕様では、複数のユーザー名を指定できるため配列形式が推奨されています

## 確認事項
- [ ] マージ後、リポジトリページにスポンサーボタンが表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)