### PR TITLE
chore: GitHub Actionsの依存関係を更新 (v4→v5)

### DIFF
--- a/.github/workflows/build-openjtalk-native.yml
+++ b/.github/workflows/build-openjtalk-native.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 30
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     
     - name: Build Docker Image
       run: |
@@ -115,7 +115,7 @@ jobs:
         arch: [x86_64]
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     
     - name: Install Dependencies
       run: |
@@ -192,7 +192,7 @@ jobs:
         abi: [arm64-v8a, armeabi-v7a, x86, x86_64]
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v3
@@ -335,7 +335,7 @@ jobs:
     timeout-minutes: 30
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     
     - name: Install CMake
       run: brew install cmake
@@ -396,10 +396,10 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       
     - name: Download All Artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         path: libraries
         
@@ -478,10 +478,10 @@ jobs:
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     
     - name: Download All Artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         path: artifacts/
     

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -30,7 +30,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v4

--- a/.github/workflows/locale-tests.yml
+++ b/.github/workflows/locale-tests.yml
@@ -35,7 +35,7 @@ jobs:
       pull-requests: write
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         lfs: true
         

--- a/.github/workflows/native-tests.yml
+++ b/.github/workflows/native-tests.yml
@@ -16,7 +16,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         lfs: true
         

--- a/.github/workflows/performance-regression.yml
+++ b/.github/workflows/performance-regression.yml
@@ -15,7 +15,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         lfs: true
         
@@ -112,7 +112,7 @@ jobs:
     
     steps:
     - name: Download All Reports
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         path: reports
         

--- a/.github/workflows/unity-build-matrix.yml
+++ b/.github/workflows/unity-build-matrix.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0  # For proper diff checking
         
@@ -96,7 +96,7 @@ jobs:
             priority: critical
             
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         lfs: true
         

--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -49,7 +49,7 @@ jobs:
           # - Android  # Temporarily disabled due to Unity licensing issues
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         lfs: true
         
@@ -151,7 +151,7 @@ jobs:
       
     steps:
     - name: Checkout for package creation
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         lfs: true
         
@@ -230,7 +230,7 @@ jobs:
         fi
         
     - name: Download build artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         path: ./artifacts
         

--- a/.github/workflows/unity-il2cpp-build.yml
+++ b/.github/workflows/unity-il2cpp-build.yml
@@ -22,7 +22,7 @@ jobs:
     name: IL2CPP Compatibility Check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         lfs: true
         
@@ -70,7 +70,7 @@ jobs:
             scriptingBackend: IL2CPP
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         lfs: true
         
@@ -154,7 +154,7 @@ jobs:
     needs: build-unity
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     
     - name: Generate Build Summary
       run: |

--- a/.github/workflows/unity-tests-windows-cli.yml
+++ b/.github/workflows/unity-tests-windows-cli.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         lfs: true
         

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -32,7 +32,7 @@ jobs:
       pull-requests: write
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         lfs: true
         
@@ -803,7 +803,7 @@ jobs:
       pull-requests: write
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         lfs: true
         
@@ -1039,7 +1039,7 @@ jobs:
       pull-requests: write
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         lfs: true
         


### PR DESCRIPTION
## 概要
Dependabot PR #45, #46の変更を統合し、GitHub Actionsの依存関係を更新します。

## 変更内容
- `actions/checkout@v4` → `v5`へアップデート
- `actions/download-artifact@v4` → `v5`へアップデート

## 更新理由
- Node.js 24のサポート
- パフォーマンスの改善
- セキュリティアップデート

## 関連PR
- #45: chore(deps): bump actions/checkout from 4 to 5
- #46: chore(deps): bump actions/download-artifact from 4 to 5

## 注記
DependabotのPRはセキュリティ上の理由でGitHub Secretsにアクセスできないため、Unity Buildテストが失敗します。
このPRは通常のブランチから作成されているため、すべてのテストが正常に実行されます。

## テストプラン
- [x] GitHub Actionsのワークフローが正常に実行されることを確認
- [x] Unity Buildテストが成功することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)