### PR TITLE
fix: Unity Package作成ステップをスキップ（Docker image不在対応）

### DIFF
--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -189,17 +189,22 @@ jobs:
           Library-PackageExport-
           Library-
           
-    - name: Create Unity Package (.unitypackage)
-      uses: game-ci/unity-builder@v4
-      env:
-        UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
-        UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
-        UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
-      with:
-        unityVersion: 6000.0.55f1
-        targetPlatform: NoTarget
-        buildMethod: uPiper.Editor.PackageExporter.ExportUnityPackageCI
-        customParameters: -outputPath ./PackageExports/uPiper-${{ steps.version.outputs.version }}.unitypackage
+    # Unity Package作成をスキップ (Unity 6000.0.55f1のDockerイメージが利用不可のため手動対応)
+    # - name: Create Unity Package (.unitypackage)
+    #   uses: game-ci/unity-builder@v4
+    #   env:
+    #     UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+    #     UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+    #     UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+    #   with:
+    #     unityVersion: 6000.0.55f1
+    #     targetPlatform: NoTarget
+    #     buildMethod: uPiper.Editor.PackageExporter.ExportUnityPackageCI
+    #     customParameters: -outputPath ./PackageExports/uPiper-${{ steps.version.outputs.version }}.unitypackage
+    
+    # Unity Packageは手動で作成するため、ディレクトリのみ作成
+    - name: Create PackageExports directory
+      run: mkdir -p ./PackageExports
         
     - name: Create UPM Package (.tgz)
       run: |


### PR DESCRIPTION
## 概要
Unity 6000.0.55f1のDockerイメージがGame-CIでまだ利用できないため、Unity Package作成ステップを一時的にスキップします。

## 問題
- Game-CI (unity-builder)がUnity 6000.0.55f1をまだサポートしていない
- `unityci/editor:ubuntu-6000.0.55f1-3`のDockerイメージが存在しない
- これによりリリースワークフロー全体が失敗

## 解決策
- Unity Package (.unitypackage)作成ステップをコメントアウト
- Unity Packageは手動で作成し、リリースに追加する運用に変更
- UPM Package (.tgz)とビルド成果物は引き続き自動生成

## 影響
- リリースワークフローが正常に完了するようになる
- Unity Packageのみ手動対応が必要

## テスト
- [ ] ワークフローが正常に実行される
- [ ] UPM Packageが作成される
- [ ] リリースが正常に作成される

🤖 Generated with [Claude Code](https://claude.ai/code)