### PR TITLE
fix: Use string constant for package version in sample paths

### DIFF
--- a/Assets/uPiper/Editor/uPiperSetup.cs
+++ b/Assets/uPiper/Editor/uPiperSetup.cs
@@ -18,6 +18,7 @@ namespace uPiper.Editor
     {
         private const string SETUP_COMPLETE_KEY = "uPiper_InitialSetupComplete_v1";
         private const string PACKAGE_NAME = "com.ayutaz.upiper";
+        private const string PACKAGE_VERSION = "0.2.0";
 
         // Target paths in Assets (made public for shared use)
         public const string TARGET_STREAMING_ASSETS_PATH = "Assets/StreamingAssets/uPiper";
@@ -375,7 +376,7 @@ namespace uPiper.Editor
             var status = new SamplesStatus();
 
             // Check for imported OpenJTalk sample
-            var openJTalkSamplePath = Path.Combine(Application.dataPath, "Samples", "uPiper", "0.1.0", "OpenJTalk Dictionary Data");
+            var openJTalkSamplePath = Path.Combine(Application.dataPath, "Samples", "uPiper", PACKAGE_VERSION, "OpenJTalk Dictionary Data");
             if (!Directory.Exists(openJTalkSamplePath))
             {
                 // Try without version number
@@ -385,7 +386,7 @@ namespace uPiper.Editor
                 Directory.Exists(Path.Combine(openJTalkSamplePath, "naist_jdic"));
 
             // Check for imported CMU sample
-            var cmuSamplePath = Path.Combine(Application.dataPath, "Samples", "uPiper", "0.1.0", "CMU Pronouncing Dictionary");
+            var cmuSamplePath = Path.Combine(Application.dataPath, "Samples", "uPiper", PACKAGE_VERSION, "CMU Pronouncing Dictionary");
             if (!Directory.Exists(cmuSamplePath))
             {
                 // Try without version number
@@ -395,7 +396,7 @@ namespace uPiper.Editor
                 File.Exists(Path.Combine(cmuSamplePath, "cmudict-0.7b.txt"));
 
             // Check for imported voice models sample
-            var modelsSamplePath = Path.Combine(Application.dataPath, "Samples", "uPiper", "0.1.0", "Voice Models");
+            var modelsSamplePath = Path.Combine(Application.dataPath, "Samples", "uPiper", PACKAGE_VERSION, "Voice Models");
             if (!Directory.Exists(modelsSamplePath))
             {
                 // Try without version number
@@ -420,7 +421,7 @@ namespace uPiper.Editor
                 {
                     var sourcePaths = new[]
                     {
-                        Path.Combine(Application.dataPath, "Samples", "uPiper", "0.1.0", "OpenJTalk Dictionary Data"),
+                        Path.Combine(Application.dataPath, "Samples", "uPiper", PACKAGE_VERSION, "OpenJTalk Dictionary Data"),
                         Path.Combine(Application.dataPath, "Samples", "uPiper", "OpenJTalk Dictionary Data")
                     };
 
@@ -451,7 +452,7 @@ namespace uPiper.Editor
                 {
                     var sourcePaths = new[]
                     {
-                        Path.Combine(Application.dataPath, "Samples", "uPiper", "0.1.0", "CMU Pronouncing Dictionary"),
+                        Path.Combine(Application.dataPath, "Samples", "uPiper", PACKAGE_VERSION, "CMU Pronouncing Dictionary"),
                         Path.Combine(Application.dataPath, "Samples", "uPiper", "CMU Pronouncing Dictionary")
                     };
 
@@ -482,7 +483,7 @@ namespace uPiper.Editor
                 {
                     var sourcePaths = new[]
                     {
-                        Path.Combine(Application.dataPath, "Samples", "uPiper", "0.1.0", "Voice Models"),
+                        Path.Combine(Application.dataPath, "Samples", "uPiper", PACKAGE_VERSION, "Voice Models"),
                         Path.Combine(Application.dataPath, "Samples", "uPiper", "Voice Models")
                     };
 


### PR DESCRIPTION
## Summary

Fixes sample detection issue after v0.2.0 update by replacing hardcoded version strings with a string constant.

## Problem

The setup wizard was failing to detect imported samples because it was looking for samples in paths with hardcoded version "0.1.0":
- `Assets/Samples/uPiper/0.1.0/OpenJTalk Dictionary Data`
- `Assets/Samples/uPiper/0.1.0/CMU Pronouncing Dictionary`
- `Assets/Samples/uPiper/0.1.0/Voice Models`

However, Package Manager v0.2.0 installs samples in `Assets/Samples/uPiper/0.2.0/` instead.

## Solution

- Added `PACKAGE_VERSION` constant set to "0.2.0"
- Replaced all 6 hardcoded "0.1.0" strings with the constant
- This ensures sample paths stay in sync with package version

## Related

Based on PR #73 by @dtaddis - reimplemented here to enable CI execution with proper Unity license access.

Closes #73

## Test Plan

- [x] Code changes applied
- [x] Pushed to remote branch
- [ ] CI passes (will verify after PR creation)
- [ ] Sample detection works with v0.2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)