### PR TITLE
chore: Prepare for v0.2.1 release

### DIFF
--- a/Assets/uPiper/Editor/uPiperSetup.cs
+++ b/Assets/uPiper/Editor/uPiperSetup.cs
@@ -18,7 +18,7 @@ namespace uPiper.Editor
     {
         private const string SETUP_COMPLETE_KEY = "uPiper_InitialSetupComplete_v1";
         private const string PACKAGE_NAME = "com.ayutaz.upiper";
-        private const string PACKAGE_VERSION = "0.2.0";
+        private const string PACKAGE_VERSION = "0.2.1";
 
         // Target paths in Assets (made public for shared use)
         public const string TARGET_STREAMING_ASSETS_PATH = "Assets/StreamingAssets/uPiper";

--- a/Assets/uPiper/package.json
+++ b/Assets/uPiper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.ayutaz.upiper",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "displayName": "uPiper",
   "description": "Text-to-Speech plugin for Unity using Piper-Plus TTS engine. Supports Japanese and English with high-quality neural voice synthesis.",
   "unity": "6000.0",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2025/10/14
+
+### 🔧 Changed
+
+- **Package Version Management**: Introduced `PACKAGE_VERSION` constant in uPiperSetup.cs (#75)
+  - Centralized version string to simplify maintenance
+  - Replaced hardcoded version strings with version constant
+  - Ensures sample path detection works correctly after version updates
+  - Thanks to @dtaddis for the original contribution
+
 ## [0.2.0] - 2025/10/11
 
 ### ✨ Added
@@ -142,5 +152,6 @@ MIT License - See [LICENSE](LICENSE) file for details
 - [Documentation](https://github.com/ayutaz/uPiper/tree/main/docs)
 - [Issues](https://github.com/ayutaz/uPiper/issues)
 
+[0.2.1]: https://github.com/ayutaz/uPiper/releases/tag/v0.2.1
 [0.2.0]: https://github.com/ayutaz/uPiper/releases/tag/v0.2.0
 [0.1.0]: https://github.com/ayutaz/uPiper/releases/tag/v0.1.0


### PR DESCRIPTION
## Summary

Prepare for v0.2.1 release with version updates and changelog.

## Changes

- Update package version to 0.2.1 in `package.json`
- Update `PACKAGE_VERSION` constant to 0.2.1 in `uPiperSetup.cs`
- Add v0.2.1 changelog entry documenting version management improvements

## What's New in v0.2.1

### 🔧 Changed

- **Package Version Management**: Introduced `PACKAGE_VERSION` constant in uPiperSetup.cs (#75)
  - Centralized version string to simplify maintenance
  - Replaced hardcoded version strings with version constant
  - Ensures sample path detection works correctly after version updates
  - Thanks to @dtaddis for the original contribution

## Test Plan

- [ ] Verify CI tests pass
- [ ] Confirm version numbers are correctly updated in all files
- [ ] Verify changelog formatting is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)