### PR TITLE
docs: リンク切れ修正とドキュメント改善

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,7 +191,10 @@ uPiper is a Unity plugin for high-quality text-to-speech synthesis using the pip
 
 ### 📝 License
 
-MIT License - See [LICENSE](LICENSE) file for details
+Apache License 2.0 - See [LICENSE](LICENSE) file for details
+
+> **Note**: ライセンスはv0.1.0のMIT LicenseからApache License 2.0に変更されました。
+> これにより、特許権の明示的な付与と、より明確な貢献者ライセンス条項が提供されます。
 
 ### 🔗 Links
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,19 @@ var config = new PiperConfig
 };
 ```
 
+### InferenceBackend.Auto の選択ロジック
+
+`InferenceBackend.Auto`を指定した場合、プラットフォームに応じて最適なバックエンドが自動選択されます：
+
+| プラットフォーム | 自動選択されるバックエンド | 理由 |
+|-----------------|--------------------------|------|
+| Windows/Linux | GPUPixel | VITSモデルとの互換性が良好 |
+| macOS | CPU | MetalはUnity.InferenceEngineで問題があるため |
+| iOS/Android | GPUPixel | モバイルGPUに最適化 |
+| WebGL | GPUPixel | WebGL専用バックエンド |
+
+> **注意**: GPUComputeはVITSモデルで音声が正しく生成されない問題があるため、現在はGPUPixelまたはCPUの使用を推奨します。
+
 詳細は[GPU推論ガイド](docs/features/gpu/gpu-inference.md)を参照してください。
 
 ## 詳細ドキュメント

--- a/docs/ARCHITECTURE_en.md
+++ b/docs/ARCHITECTURE_en.md
@@ -1,6 +1,6 @@
 # uPiper Architecture Document
 
-[🇯🇵 日本語](../ja/ARCHITECTURE.md) | [🇬🇧 **English**](../en/ARCHITECTURE.md)
+[🇯🇵 日本語](ARCHITECTURE_ja.md) | [🇬🇧 **English**](ARCHITECTURE_en.md)
 
 ## Overview
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,10 +8,9 @@
   - implementation-guide.md - 実装ガイド
   - performance-optimization.md - パフォーマンス最適化
   - technical-report.md - 技術レポート
-- **ios/** - iOS実装（Phase 5）
-  - phase5-ios-detailed-implementation-plan.md - 詳細実装計画
-  - phase5-ios-implementation-plan.md - 実装計画
-  - phase5-ios-technical-research.md - 技術調査
+- **ios/** - iOS実装 ✅ 完了（v0.2.0）
+  - iOS対応はv0.2.0で完了しました
+  - 詳細は[CHANGELOG](../CHANGELOG.md)を参照
 
 ### 🚀 features/ - 機能別ドキュメント
 - **phonemization/** - 音素化システム

--- a/docs/features/asian-language-support.md
+++ b/docs/features/asian-language-support.md
@@ -1,6 +1,6 @@
 # アジア言語サポート実装ガイド
 
-[🇯🇵 **日本語**](../../ja/guides/implementation/asian-language-support.md) | [🇬🇧 English](../../en/guides/implementation/asian-language-support.md)
+<!-- 日本語のみのドキュメント -->
 
 ## 概要
 

--- a/docs/features/phonemization/implementation-summary.md
+++ b/docs/features/phonemization/implementation-summary.md
@@ -1,6 +1,6 @@
 # Phase 3 実装サマリー: MITライセンス多言語音素化
 
-[🇯🇵 **日本語**](../../../ja/guides/implementation/phonemization-system/implementation-summary.md) | [🇬🇧 English](../../../en/guides/implementation/phonemization-system/implementation-summary.md)
+<!-- 日本語のみのドキュメント -->
 
 ## 概要
 

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -127,5 +127,5 @@ For developers working on uPiper itself:
 
 After setup is complete:
 1. Check out the sample scene in the imported **Basic TTS Demo**
-2. See the [API Documentation](api-reference.md) for usage examples
-3. Explore the [Configuration Guide](configuration.md) for customization options
+2. See the [Architecture Documentation](ARCHITECTURE_en.md) for technical details and usage examples
+3. Explore the [GPU Inference Guide](features/gpu/gpu-inference.md) for performance customization


### PR DESCRIPTION
## 概要

ドキュメントのリンク切れ修正と改善を行いました。

## 変更内容

### 🔴 リンク切れ修正

| ファイル | 修正内容 |
|---------|---------|
| `docs/setup-guide.md` | 存在しない`api-reference.md`、`configuration.md`を既存ドキュメントへのリンクに変更 |
| `docs/ARCHITECTURE_en.md` | 無効な言語フォルダ参照 `../ja/ARCHITECTURE.md` → `ARCHITECTURE_ja.md` に修正 |
| `docs/features/asian-language-support.md` | 無効な言語フォルダ参照を削除 |
| `docs/features/phonemization/implementation-summary.md` | 無効な言語フォルダ参照を削除 |

### 🟡 README改善

- `README.md`: `InferenceBackend.Auto`のプラットフォーム別選択ロジック表を追加

### 🟢 その他

- `docs/README.md`: iOS実装計画 → 完了（v0.2.0）に更新
- `CHANGELOG.md`: MIT License → Apache License 2.0に修正、変更理由を追記

## テスト計画

- [x] リンクが正しく機能することを確認
- [x] ドキュメントの表示が正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)