### PR TITLE
chore(deps): bump actions/cache from 4 to 5

### DIFF
--- a/.github/workflows/locale-tests.yml
+++ b/.github/workflows/locale-tests.yml
@@ -132,7 +132,7 @@ jobs:
       shell: powershell
 
     - name: Cache Unity Library
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: Library
         key: Library-${{ matrix.os }}-${{ matrix.locale }}-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}

--- a/.github/workflows/unity-build-matrix.yml
+++ b/.github/workflows/unity-build-matrix.yml
@@ -112,7 +112,7 @@ jobs:
         swap-storage: true
         
     - name: Cache Library
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: Library
         key: Library-${{ matrix.backend }}-${{ matrix.platform }}-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}

--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -54,7 +54,7 @@ jobs:
         lfs: true
         
     - name: Cache Library
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: Library
         key: Library-${{ matrix.targetPlatform }}-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}
@@ -229,7 +229,7 @@ jobs:
         fi
         
     - name: Cache Library for Package Export
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: Library
         key: Library-PackageExport-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}

--- a/.github/workflows/unity-il2cpp-build.yml
+++ b/.github/workflows/unity-il2cpp-build.yml
@@ -75,7 +75,7 @@ jobs:
         lfs: true
         
     - name: Cache Library
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: Library
         key: Library-${{ matrix.scriptingBackend }}-${{ matrix.targetPlatform }}-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -90,7 +90,7 @@ jobs:
       shell: bash
         
     - name: Cache Library
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: Library
         key: Library-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}
@@ -843,7 +843,7 @@ jobs:
         
     # Unity Hubとエディターのキャッシュ
     - name: Cache Unity
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           /Applications/Unity*


### PR DESCRIPTION
## Summary

- `actions/cache`をv4からv5にアップデート
- Dependabot PR #90 の変更を手動で適用（CIパス用）

## Changes

以下のワークフローファイルで`actions/cache@v4`→`actions/cache@v5`に更新:

- `.github/workflows/locale-tests.yml`
- `.github/workflows/unity-build-matrix.yml`
- `.github/workflows/unity-build.yml`
- `.github/workflows/unity-il2cpp-build.yml`
- `.github/workflows/unity-tests.yml`

## Notes

- actions/cache v5はNode.js 24ランタイムを使用
- Actions Runner 2.327.1以上が必要（GitHub-hostedランナーは対応済み）

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)