### PR TITLE
feat: CI/CDで.unitypackageを自動ビルドしてリリースに添付

### DIFF
--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -243,12 +243,6 @@ jobs:
       with:
         path: ./artifacts
 
-    - name: Download UnityPackage artifact
-      uses: actions/download-artifact@v8
-      with:
-        name: UnityPackage
-        path: ./artifacts/UnityPackage
-
     - name: Package builds
       run: |
         cd artifacts

--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -170,10 +170,60 @@ jobs:
         path: build/${{ matrix.targetPlatform }}
         retention-days: 7
 
+  # .unitypackageエクスポート（タグプッシュ時）
+  export-unitypackage:
+    name: Export .unitypackage
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+
+    steps:
+    - uses: actions/checkout@v5
+      with:
+        lfs: true
+
+    - uses: actions/checkout@v5
+      with:
+        repository: ayutaz/dot-net-g2p
+        ref: v1.8.2
+        path: dot-net-g2p
+
+    - name: Fix local package paths for CI
+      shell: bash
+      run: sed -i 's|file:../../dot-net-g2p/src|file:../dot-net-g2p/src|g' Packages/manifest.json
+
+    - name: Cache Library
+      uses: actions/cache@v5
+      with:
+        path: Library
+        key: Library-Export-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}
+        restore-keys: |
+          Library-Export-
+          Library-
+
+    - name: Export .unitypackage
+      uses: game-ci/unity-builder@v4
+      env:
+        CI: "true"
+        UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+        UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+        UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+      with:
+        unityVersion: 6000.0.58f2
+        targetPlatform: StandaloneLinux64
+        buildMethod: uPiper.Editor.PackageExporter.ExportUnityPackageCI
+        allowDirtyBuild: true
+
+    - name: Upload .unitypackage artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: UnityPackage
+        path: ./Exports/*.unitypackage
+        retention-days: 7
+
   # リリースへのビルド成果物アップロード（タグプッシュ時）
   upload-to-release:
     name: Upload Build Artifacts to Release
-    needs: build
+    needs: [build, export-unitypackage]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
@@ -192,6 +242,12 @@ jobs:
       uses: actions/download-artifact@v8
       with:
         path: ./artifacts
+
+    - name: Download UnityPackage artifact
+      uses: actions/download-artifact@v8
+      with:
+        name: UnityPackage
+        path: ./artifacts/UnityPackage
 
     - name: Package builds
       run: |
@@ -223,5 +279,11 @@ jobs:
           if [ -f "$zip" ]; then
             echo "Uploading $zip"
             gh release upload "$TAG" "$zip" --repo "${{ github.repository }}" --clobber
+          fi
+        done
+        for pkg in artifacts/UnityPackage/*.unitypackage; do
+          if [ -f "$pkg" ]; then
+            echo "Uploading $pkg"
+            gh release upload "$TAG" "$pkg" --repo "${{ github.repository }}" --clobber
           fi
         done

--- a/Assets/uPiper/Editor/PackageExporter.cs
+++ b/Assets/uPiper/Editor/PackageExporter.cs
@@ -269,6 +269,13 @@ namespace uPiper.Editor
                 paths.Add(samplesPath);
             }
 
+            // Add StreamingAssets dictionaries if they exist
+            var streamingAssetsPath = "Assets/StreamingAssets/uPiper";
+            if (Directory.Exists(streamingAssetsPath))
+            {
+                paths.Add(streamingAssetsPath);
+            }
+
             return paths;
         }
 

--- a/Assets/uPiper/README.md
+++ b/Assets/uPiper/README.md
@@ -58,21 +58,20 @@ Package Managerからインストール後、**必ず以下の手順でデータ
 2. Unity のメニューから `Assets > Import Package > Custom Package...` を選択
 3. ダウンロードした `.unitypackage` ファイルを選択してインポート
 
-> ⚠️ **注意**: `.unitypackage` には DotNetG2P パッケージが含まれていません。以下の依存パッケージを `Packages/manifest.json` の `dependencies` に手動で追加してください：
+> **注意**: `.unitypackage` には DotNetG2P パッケージおよび一部のUnityパッケージが含まれていません。`Packages/manifest.json` の `"dependencies"` に以下のエントリを追加してください（既存のエントリは削除しないでください）：
 
-```json
-{
-  "dependencies": {
-    "com.dotnetg2p.core": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Core#v1.8.2",
-    "com.dotnetg2p.mecab": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.MeCab#v1.8.2",
-    "com.dotnetg2p.english": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.English#v1.8.2",
-    "com.dotnetg2p.chinese": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Chinese#v1.8.2",
-    "com.dotnetg2p.korean": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Korean#v1.8.2",
-    "com.dotnetg2p.spanish": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Spanish#v1.8.2",
-    "com.dotnetg2p.french": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.French#v1.8.2",
-    "com.dotnetg2p.portuguese": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Portuguese#v1.8.2"
-  }
-}
+```jsonc
+// Packages/manifest.json の "dependencies" 内に以下を追加:
+"com.unity.ai.inference": "2.5.0",
+"com.unity.nuget.newtonsoft-json": "3.2.1",
+"com.dotnetg2p.core": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Core#v1.8.2",
+"com.dotnetg2p.mecab": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.MeCab#v1.8.2",
+"com.dotnetg2p.english": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.English#v1.8.2",
+"com.dotnetg2p.chinese": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Chinese#v1.8.2",
+"com.dotnetg2p.korean": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Korean#v1.8.2",
+"com.dotnetg2p.spanish": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Spanish#v1.8.2",
+"com.dotnetg2p.french": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.French#v1.8.2",
+"com.dotnetg2p.portuguese": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Portuguese#v1.8.2"
 ```
 
 ### トラブルシューティング

--- a/Assets/uPiper/README.md
+++ b/Assets/uPiper/README.md
@@ -61,14 +61,18 @@ Package Managerからインストール後、**必ず以下の手順でデータ
 > ⚠️ **注意**: `.unitypackage` には DotNetG2P パッケージが含まれていません。以下の依存パッケージを `Packages/manifest.json` の `dependencies` に手動で追加してください：
 
 ```json
-"com.dotnetg2p.core": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Core#v1.8.2",
-"com.dotnetg2p.mecab": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.MeCab#v1.8.2",
-"com.dotnetg2p.english": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.English#v1.8.2",
-"com.dotnetg2p.chinese": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Chinese#v1.8.2",
-"com.dotnetg2p.spanish": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Spanish#v1.8.2",
-"com.dotnetg2p.french": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.French#v1.8.2",
-"com.dotnetg2p.portuguese": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Portuguese#v1.8.2",
-"com.dotnetg2p.korean": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Korean#v1.8.2"
+{
+  "dependencies": {
+    "com.dotnetg2p.core": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Core#v1.8.2",
+    "com.dotnetg2p.mecab": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.MeCab#v1.8.2",
+    "com.dotnetg2p.english": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.English#v1.8.2",
+    "com.dotnetg2p.chinese": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Chinese#v1.8.2",
+    "com.dotnetg2p.korean": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Korean#v1.8.2",
+    "com.dotnetg2p.spanish": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Spanish#v1.8.2",
+    "com.dotnetg2p.french": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.French#v1.8.2",
+    "com.dotnetg2p.portuguese": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Portuguese#v1.8.2"
+  }
+}
 ```
 
 ### トラブルシューティング

--- a/Assets/uPiper/README.md
+++ b/Assets/uPiper/README.md
@@ -52,8 +52,24 @@ Package Managerからインストール後、**必ず以下の手順でデータ
 
 ### 手動インストール
 
-1. [Releases](https://github.com/ayutaz/uPiper/releases) から最新版をダウンロード
-2. Unity プロジェクトにインポート
+#### .unitypackage を使用する場合
+
+1. [Releases](https://github.com/ayutaz/uPiper/releases) ページから最新の `.unitypackage` ファイルをダウンロード
+2. Unity のメニューから `Assets > Import Package > Custom Package...` を選択
+3. ダウンロードした `.unitypackage` ファイルを選択してインポート
+
+> ⚠️ **注意**: `.unitypackage` には DotNetG2P パッケージが含まれていません。以下の依存パッケージを `Packages/manifest.json` の `dependencies` に手動で追加してください：
+
+```json
+"com.dotnetg2p.core": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Core#v1.8.2",
+"com.dotnetg2p.mecab": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.MeCab#v1.8.2",
+"com.dotnetg2p.english": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.English#v1.8.2",
+"com.dotnetg2p.chinese": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Chinese#v1.8.2",
+"com.dotnetg2p.spanish": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Spanish#v1.8.2",
+"com.dotnetg2p.french": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.French#v1.8.2",
+"com.dotnetg2p.portuguese": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Portuguese#v1.8.2",
+"com.dotnetg2p.korean": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Korean#v1.8.2"
+```
 
 ### トラブルシューティング
 

--- a/README.en.md
+++ b/README.en.md
@@ -15,7 +15,7 @@ A Unity plugin for [piper-plus](https://github.com/ayutaz/piper-plus) - High-qua
 - [Installation](#installation)
   - [Via OpenUPM (Recommended)](#via-openupm-recommended)
   - [Via Git URL](#via-git-url)
-  - [From Package Files](#from-package-files)
+  - [Install from Package File](#install-from-package-file)
   - [Troubleshooting](#troubleshooting)
 - [Supported Platforms](#supported-platforms)
 - [GPU Inference](#gpu-inference)
@@ -123,10 +123,28 @@ After importing samples:
 
 > ⚠️ **Important**: TTS functionality will not work without importing the dictionary data
 
-### From Package Files
-Download the latest package from [Releases](https://github.com/ayutaz/uPiper/releases):
-- **Unity Package (.unitypackage)**: Legacy format, compatible with all Unity versions
-- **UPM Package (.tgz)**: For Unity Package Manager, Unity 2019.3+
+### Install from Package File
+
+Download the latest version from the [Releases](https://github.com/ayutaz/uPiper/releases) page.
+
+#### Unity Package (.unitypackage)
+
+1. Download `uPiper-vX.X.X.unitypackage` from [Releases](https://github.com/ayutaz/uPiper/releases)
+2. In Unity Editor, go to `Assets > Import Package > Custom Package`
+3. Select the downloaded `.unitypackage` file and click "Import"
+
+> **Note**: The `.unitypackage` does not include DotNetG2P packages. Add the following packages to your `Packages/manifest.json` `dependencies`:
+
+```json
+"com.dotnetg2p.core": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Core#v1.8.2",
+"com.dotnetg2p.mecab": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.MeCab#v1.8.2",
+"com.dotnetg2p.english": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.English#v1.8.2",
+"com.dotnetg2p.chinese": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Chinese#v1.8.2",
+"com.dotnetg2p.korean": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Korean#v1.8.2",
+"com.dotnetg2p.spanish": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Spanish#v1.8.2",
+"com.dotnetg2p.french": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.French#v1.8.2",
+"com.dotnetg2p.portuguese": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Portuguese#v1.8.2"
+```
 
 ### Troubleshooting
 

--- a/README.en.md
+++ b/README.en.md
@@ -133,21 +133,20 @@ Download the latest version from the [Releases](https://github.com/ayutaz/uPiper
 2. In Unity Editor, go to `Assets > Import Package > Custom Package`
 3. Select the downloaded `.unitypackage` file and click "Import"
 
-> **Note**: The `.unitypackage` does not include DotNetG2P packages. Add the following packages to your `Packages/manifest.json` `dependencies`:
+> **Note**: The `.unitypackage` does not include DotNetG2P packages or some required Unity packages. Add the following entries to the `"dependencies"` section of your `Packages/manifest.json` (do not remove existing entries):
 
-```json
-{
-  "dependencies": {
-    "com.dotnetg2p.core": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Core#v1.8.2",
-    "com.dotnetg2p.mecab": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.MeCab#v1.8.2",
-    "com.dotnetg2p.english": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.English#v1.8.2",
-    "com.dotnetg2p.chinese": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Chinese#v1.8.2",
-    "com.dotnetg2p.korean": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Korean#v1.8.2",
-    "com.dotnetg2p.spanish": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Spanish#v1.8.2",
-    "com.dotnetg2p.french": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.French#v1.8.2",
-    "com.dotnetg2p.portuguese": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Portuguese#v1.8.2"
-  }
-}
+```jsonc
+// Add the following to "dependencies" in Packages/manifest.json:
+"com.unity.ai.inference": "2.5.0",
+"com.unity.nuget.newtonsoft-json": "3.2.1",
+"com.dotnetg2p.core": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Core#v1.8.2",
+"com.dotnetg2p.mecab": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.MeCab#v1.8.2",
+"com.dotnetg2p.english": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.English#v1.8.2",
+"com.dotnetg2p.chinese": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Chinese#v1.8.2",
+"com.dotnetg2p.korean": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Korean#v1.8.2",
+"com.dotnetg2p.spanish": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Spanish#v1.8.2",
+"com.dotnetg2p.french": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.French#v1.8.2",
+"com.dotnetg2p.portuguese": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Portuguese#v1.8.2"
 ```
 
 ### Troubleshooting

--- a/README.en.md
+++ b/README.en.md
@@ -136,14 +136,18 @@ Download the latest version from the [Releases](https://github.com/ayutaz/uPiper
 > **Note**: The `.unitypackage` does not include DotNetG2P packages. Add the following packages to your `Packages/manifest.json` `dependencies`:
 
 ```json
-"com.dotnetg2p.core": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Core#v1.8.2",
-"com.dotnetg2p.mecab": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.MeCab#v1.8.2",
-"com.dotnetg2p.english": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.English#v1.8.2",
-"com.dotnetg2p.chinese": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Chinese#v1.8.2",
-"com.dotnetg2p.korean": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Korean#v1.8.2",
-"com.dotnetg2p.spanish": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Spanish#v1.8.2",
-"com.dotnetg2p.french": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.French#v1.8.2",
-"com.dotnetg2p.portuguese": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Portuguese#v1.8.2"
+{
+  "dependencies": {
+    "com.dotnetg2p.core": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Core#v1.8.2",
+    "com.dotnetg2p.mecab": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.MeCab#v1.8.2",
+    "com.dotnetg2p.english": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.English#v1.8.2",
+    "com.dotnetg2p.chinese": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Chinese#v1.8.2",
+    "com.dotnetg2p.korean": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Korean#v1.8.2",
+    "com.dotnetg2p.spanish": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Spanish#v1.8.2",
+    "com.dotnetg2p.french": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.French#v1.8.2",
+    "com.dotnetg2p.portuguese": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Portuguese#v1.8.2"
+  }
+}
 ```
 
 ### Troubleshooting

--- a/README.md
+++ b/README.md
@@ -136,14 +136,18 @@ Package Managerからインストール後、**必ず以下の手順でデータ
 > **注意**: `.unitypackage`にはDotNetG2Pパッケージが含まれません。以下のパッケージを `Packages/manifest.json` の `dependencies` に追加してください：
 
 ```json
-"com.dotnetg2p.core": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Core#v1.8.2",
-"com.dotnetg2p.mecab": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.MeCab#v1.8.2",
-"com.dotnetg2p.english": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.English#v1.8.2",
-"com.dotnetg2p.chinese": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Chinese#v1.8.2",
-"com.dotnetg2p.korean": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Korean#v1.8.2",
-"com.dotnetg2p.spanish": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Spanish#v1.8.2",
-"com.dotnetg2p.french": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.French#v1.8.2",
-"com.dotnetg2p.portuguese": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Portuguese#v1.8.2"
+{
+  "dependencies": {
+    "com.dotnetg2p.core": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Core#v1.8.2",
+    "com.dotnetg2p.mecab": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.MeCab#v1.8.2",
+    "com.dotnetg2p.english": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.English#v1.8.2",
+    "com.dotnetg2p.chinese": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Chinese#v1.8.2",
+    "com.dotnetg2p.korean": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Korean#v1.8.2",
+    "com.dotnetg2p.spanish": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Spanish#v1.8.2",
+    "com.dotnetg2p.french": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.French#v1.8.2",
+    "com.dotnetg2p.portuguese": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Portuguese#v1.8.2"
+  }
+}
 ```
 
 ### トラブルシューティング

--- a/README.md
+++ b/README.md
@@ -124,9 +124,27 @@ Package Managerからインストール後、**必ず以下の手順でデータ
 > ⚠️ **重要**: 辞書データをインポートしないとTTS機能は動作しません
 
 ### パッケージファイルからのインストール
-[Releases](https://github.com/ayutaz/uPiper/releases)から最新のパッケージファイルをダウンロード：
-- **Unity Package (.unitypackage)**: レガシー形式、全てのUnityバージョンで使用可能
-- **UPM Package (.tgz)**: Unity Package Manager用、Unity 2019.3以降
+
+[Releases](https://github.com/ayutaz/uPiper/releases)ページから最新版をダウンロードしてインストールできます。
+
+#### Unity Package (.unitypackage)
+
+1. [Releases](https://github.com/ayutaz/uPiper/releases)から `uPiper-vX.X.X.unitypackage` をダウンロード
+2. Unity Editorで `Assets > Import Package > Custom Package` を選択
+3. ダウンロードした `.unitypackage` ファイルを選択し、「Import」をクリック
+
+> **注意**: `.unitypackage`にはDotNetG2Pパッケージが含まれません。以下のパッケージを `Packages/manifest.json` の `dependencies` に追加してください：
+
+```json
+"com.dotnetg2p.core": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Core#v1.8.2",
+"com.dotnetg2p.mecab": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.MeCab#v1.8.2",
+"com.dotnetg2p.english": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.English#v1.8.2",
+"com.dotnetg2p.chinese": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Chinese#v1.8.2",
+"com.dotnetg2p.korean": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Korean#v1.8.2",
+"com.dotnetg2p.spanish": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Spanish#v1.8.2",
+"com.dotnetg2p.french": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.French#v1.8.2",
+"com.dotnetg2p.portuguese": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Portuguese#v1.8.2"
+```
 
 ### トラブルシューティング
 

--- a/README.md
+++ b/README.md
@@ -133,21 +133,20 @@ Package Managerからインストール後、**必ず以下の手順でデータ
 2. Unity Editorで `Assets > Import Package > Custom Package` を選択
 3. ダウンロードした `.unitypackage` ファイルを選択し、「Import」をクリック
 
-> **注意**: `.unitypackage`にはDotNetG2Pパッケージが含まれません。以下のパッケージを `Packages/manifest.json` の `dependencies` に追加してください：
+> **注意**: `.unitypackage`にはDotNetG2Pパッケージおよび一部のUnityパッケージが含まれません。`Packages/manifest.json` の `"dependencies"` に以下のエントリを追加してください（既存のエントリは削除しないでください）：
 
-```json
-{
-  "dependencies": {
-    "com.dotnetg2p.core": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Core#v1.8.2",
-    "com.dotnetg2p.mecab": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.MeCab#v1.8.2",
-    "com.dotnetg2p.english": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.English#v1.8.2",
-    "com.dotnetg2p.chinese": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Chinese#v1.8.2",
-    "com.dotnetg2p.korean": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Korean#v1.8.2",
-    "com.dotnetg2p.spanish": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Spanish#v1.8.2",
-    "com.dotnetg2p.french": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.French#v1.8.2",
-    "com.dotnetg2p.portuguese": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Portuguese#v1.8.2"
-  }
-}
+```jsonc
+// Packages/manifest.json の "dependencies" 内に以下を追加:
+"com.unity.ai.inference": "2.5.0",
+"com.unity.nuget.newtonsoft-json": "3.2.1",
+"com.dotnetg2p.core": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Core#v1.8.2",
+"com.dotnetg2p.mecab": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.MeCab#v1.8.2",
+"com.dotnetg2p.english": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.English#v1.8.2",
+"com.dotnetg2p.chinese": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Chinese#v1.8.2",
+"com.dotnetg2p.korean": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Korean#v1.8.2",
+"com.dotnetg2p.spanish": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Spanish#v1.8.2",
+"com.dotnetg2p.french": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.French#v1.8.2",
+"com.dotnetg2p.portuguese": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Portuguese#v1.8.2"
 ```
 
 ### トラブルシューティング

--- a/docs/development/CI_CD_GUIDE.md
+++ b/docs/development/CI_CD_GUIDE.md
@@ -14,6 +14,7 @@ uPiperプロジェクトでは、GitHub Actionsを使用して継続的インテ
 - Unity 6000.0.58f2使用
 - Mono2x/IL2CPPバックエンド対応
 - 自動リリース作成（タグプッシュ時）
+- `.unitypackage`自動エクスポート・リリース添付（タグプッシュ時）
 
 ### 2. unity-build-matrix.yml (PR Quality Check)
 **目的**: PR時の包括的なビルド検証
@@ -139,6 +140,8 @@ developブランチにも同様のルールを設定：
 2. unity-build.ymlが自動的にビルドを開始
 3. 全プラットフォームのビルドが完了後、GitHubリリースを作成
 4. ビルド成果物が自動的にリリースに添付
+5. `export-unitypackage`ジョブで`PackageExporter.ExportUnityPackageCI`を呼び出し`.unitypackage`を自動生成
+6. `upload-to-release`ジョブで`.unitypackage`をGitHub Releaseに添付
 
 ## セキュリティ
 

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -15,7 +15,26 @@ Add uPiper to your project via Package Manager:
 
 ### 2. Unity Package (.unitypackage)
 
-Download and import the latest release from [GitHub Releases](https://github.com/ayutaz/uPiper/releases)
+1. Download `uPiper-vX.X.X.unitypackage` from [GitHub Releases](https://github.com/ayutaz/uPiper/releases)
+2. In Unity Editor, go to **Assets > Import Package > Custom Package**
+3. Select the downloaded `.unitypackage` file and click **Import**
+4. Add the DotNetG2P dependency packages to your `Packages/manifest.json`
+
+The `.unitypackage` does not include DotNetG2P packages. Add the following entries to the `"dependencies"` section of your `Packages/manifest.json`:
+
+```json
+{
+  "dependencies": {
+    "com.dotnetg2p.chinese": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Chinese#v1.8.2",
+    "com.dotnetg2p.core": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Core#v1.8.2",
+    "com.dotnetg2p.english": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.English#v1.8.2",
+    "com.dotnetg2p.french": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.French#v1.8.2",
+    "com.dotnetg2p.korean": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Korean#v1.8.2",
+    "com.dotnetg2p.mecab": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.MeCab#v1.8.2",
+    "com.dotnetg2p.portuguese": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Portuguese#v1.8.2",
+    "com.dotnetg2p.spanish": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Spanish#v1.8.2"
+  }
+}
 
 ## Required Data Setup
 

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -20,21 +20,20 @@ Add uPiper to your project via Package Manager:
 3. Select the downloaded `.unitypackage` file and click **Import**
 4. Add the DotNetG2P dependency packages to your `Packages/manifest.json`
 
-The `.unitypackage` does not include DotNetG2P packages. Add the following entries to the `"dependencies"` section of your `Packages/manifest.json`:
+The `.unitypackage` does not include DotNetG2P packages or some required Unity packages. Add the following entries to the `"dependencies"` section of your `Packages/manifest.json` (do not remove existing entries):
 
-```json
-{
-  "dependencies": {
-    "com.dotnetg2p.chinese": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Chinese#v1.8.2",
-    "com.dotnetg2p.core": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Core#v1.8.2",
-    "com.dotnetg2p.english": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.English#v1.8.2",
-    "com.dotnetg2p.french": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.French#v1.8.2",
-    "com.dotnetg2p.korean": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Korean#v1.8.2",
-    "com.dotnetg2p.mecab": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.MeCab#v1.8.2",
-    "com.dotnetg2p.portuguese": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Portuguese#v1.8.2",
-    "com.dotnetg2p.spanish": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Spanish#v1.8.2"
-  }
-}
+```jsonc
+// Add the following to "dependencies" in Packages/manifest.json:
+"com.unity.ai.inference": "2.5.0",
+"com.unity.nuget.newtonsoft-json": "3.2.1",
+"com.dotnetg2p.chinese": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Chinese#v1.8.2",
+"com.dotnetg2p.core": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Core#v1.8.2",
+"com.dotnetg2p.english": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.English#v1.8.2",
+"com.dotnetg2p.french": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.French#v1.8.2",
+"com.dotnetg2p.korean": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Korean#v1.8.2",
+"com.dotnetg2p.mecab": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.MeCab#v1.8.2",
+"com.dotnetg2p.portuguese": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Portuguese#v1.8.2",
+"com.dotnetg2p.spanish": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Spanish#v1.8.2"
 ```
 
 ## Required Data Setup

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -35,6 +35,7 @@ The `.unitypackage` does not include DotNetG2P packages. Add the following entri
     "com.dotnetg2p.spanish": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Spanish#v1.8.2"
   }
 }
+```
 
 ## Required Data Setup
 


### PR DESCRIPTION
## Summary
- CI/CDで.unitypackageを自動ビルドしてリリースに添付する機能を追加
- ドキュメント整合性の修正と冗長なartifactダウンロード削除
- JSONスニペットを有効なJSON構造に修正

> 元PR #142 がmainに誤マージされたため、develop向けに再作成

## Test plan
- [ ] CIが通ること