### PR TITLE
ci: GitHub Actions バージョンバンプ (checkout v5→v6)

### DIFF
--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -177,11 +177,11 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         lfs: true
 
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         repository: ayutaz/dot-net-g2p
         ref: v1.8.2


### PR DESCRIPTION
## Summary

#147 (Dependabot) の残りの対応。PR #148 マージ時に大部分は反映済みで、`unity-build.yml` の export-unitypackage ジョブ内の `actions/checkout@v5` → `v6` の2箇所のみ未適用だった。

- `actions/checkout` v5 → v6 (unity-build.yml export-unitypackage ジョブ、2箇所)

Closes #147

## Test plan

- [ ] CI ワークフローが正常に動作すること