### PR TITLE
chore(deps): Unity 6000.3.11f1 アップグレード + uLoopMCP 2.1.8 + パッケージ更新

### DIFF
--- a/.github/workflows/deploy-webgl.yml
+++ b/.github/workflows/deploy-webgl.yml
@@ -75,7 +75,7 @@ jobs:
         UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
         UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
       with:
-        unityVersion: 6000.0.58f2
+        unityVersion: 6000.3.11f1
         targetPlatform: WebGL
         buildName: Web
         buildsPath: build

--- a/.github/workflows/unity-build-matrix.yml
+++ b/.github/workflows/unity-build-matrix.yml
@@ -145,7 +145,7 @@ jobs:
         UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
         UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
       with:
-        unityVersion: 6000.0.58f2
+        unityVersion: 6000.3.11f1
         targetPlatform: ${{ matrix.platform }}
         buildMethod: UnityBuilderAction.BuildScript.Build
         allowDirtyBuild: true

--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -103,7 +103,7 @@ jobs:
         UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
         UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
       with:
-        unityVersion: 6000.0.58f2
+        unityVersion: 6000.3.11f1
         targetPlatform: ${{ matrix.targetPlatform }}
         buildName: uPiper${{ github.event_name == 'workflow_dispatch' && github.event.inputs.useIL2CPP == 'true' && '-IL2CPP' || '' }}
         buildsPath: build
@@ -144,7 +144,7 @@ jobs:
         UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
         UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
       with:
-        unityVersion: 6000.0.58f2
+        unityVersion: 6000.3.11f1
         targetPlatform: ${{ matrix.targetPlatform }}
         buildName: uPiper${{ github.event_name == 'workflow_dispatch' && github.event.inputs.useIL2CPP == 'true' && '-IL2CPP' || '' }}
         buildsPath: build
@@ -188,7 +188,7 @@ jobs:
         UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
         UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
       with:
-        unityVersion: 6000.0.58f2
+        unityVersion: 6000.3.11f1
         targetPlatform: StandaloneLinux64
         buildMethod: uPiper.Editor.PackageExporter.ExportUnityPackageCI
         allowDirtyBuild: true

--- a/.github/workflows/unity-il2cpp-build.yml
+++ b/.github/workflows/unity-il2cpp-build.yml
@@ -129,7 +129,7 @@ jobs:
         UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
         UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
       with:
-        unityVersion: 6000.0.58f2
+        unityVersion: 6000.3.11f1
         targetPlatform: ${{ matrix.targetPlatform }}
         buildsPath: build
         buildMethod: UnityBuilderAction.BuildScript.Build
@@ -196,7 +196,7 @@ jobs:
         echo "" >> build-summary.md
         echo "## Build Configuration" >> build-summary.md
         echo "" >> build-summary.md
-        echo "- Unity Version: 6000.0.58f2" >> build-summary.md
+        echo "- Unity Version: 6000.3.11f1" >> build-summary.md
         echo "- link.xml: Present ✅" >> build-summary.md
         echo "- [Preserve] attributes: Applied ✅" >> build-summary.md
         echo "- Custom build script: UnityBuilderAction.BuildScript ✅" >> build-summary.md

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -44,7 +44,7 @@ jobs:
         UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
         UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
       with:
-        unityVersion: 6000.0.58f2
+        unityVersion: 6000.3.11f1
         testMode: EditMode
         artifactsPath: test-results
         githubToken: ${{ github.token }}

--- a/Assets/uPiper/README.md
+++ b/Assets/uPiper/README.md
@@ -213,7 +213,7 @@ uPiper/
 
 ## 必要要件
 
-- Unity 6000.0.58f2 以降
+- Unity 6000.3.11f1 以降
 - Unity AI Inference Engine (com.unity.ai.inference) 2.5.0
 - 各プラットフォームの要件:
   - Windows: Windows 10 以降（x64のみ）

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PlatformInitLoggingTests を値アサーション付きに書き直し
 - AudioSynthesisCache の `[Obsolete]` API → NativeArray対応
 - BitConverter.GetBytes → union struct（GCフリー化）
+- Unity Editor 6000.0.58f2 → 6000.3.11f1 にアップグレード（CIワークフロー・ドキュメントの版数表記も更新）
+- uLoopMCP 0.50.0 → 2.1.8、Unityパッケージ更新（inputsystem/test-framework/visualstudio/codecoverage 等）、WebGLInput 追加
 
 ### Deprecated
 

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -3,7 +3,10 @@
     {
       "name": "OpenUPM",
       "url": "https://package.openupm.com",
-      "scopes": ["org.nuget", "io.github.hatayama.uloopmcp"]
+      "scopes": [
+        "org.nuget",
+        "io.github.hatayama.uloopmcp"
+      ]
     }
   ],
   "dependencies": {
@@ -15,17 +18,19 @@
     "com.dotnetg2p.mecab": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.MeCab#v1.8.2",
     "com.dotnetg2p.portuguese": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Portuguese#v1.8.2",
     "com.dotnetg2p.spanish": "https://github.com/ayutaz/dot-net-g2p.git?path=src/DotNetG2P.Spanish#v1.8.2",
-    "io.github.hatayama.uloopmcp": "0.50.0",
-    "org.nuget.microsoft.codeanalysis.csharp": "4.14.0",
+    "com.github.kou-yeung": "https://github.com/kou-yeung/WebGLInput.git?path=Assets/WebGLSupport#1.4.5",
     "com.unity.ai.inference": "2.5.0",
-    "com.unity.ide.visualstudio": "2.0.25",
-    "com.unity.inputsystem": "1.14.2",
-    "com.unity.mobile.android-logcat": "1.4.6",
+    "com.unity.ide.visualstudio": "2.0.26",
+    "com.unity.inputsystem": "1.19.0",
+    "com.unity.mobile.android-logcat": "1.4.7",
     "com.unity.nuget.newtonsoft-json": "3.2.2",
-    "com.unity.test-framework": "1.5.1",
-    "com.unity.testtools.codecoverage": "1.2.7",
+    "com.unity.test-framework": "1.6.0",
+    "com.unity.testtools.codecoverage": "1.3.0",
     "com.unity.ugui": "2.0.0",
+    "io.github.hatayama.uloopmcp": "2.1.8",
+    "org.nuget.microsoft.codeanalysis.csharp": "4.14.0",
     "com.unity.modules.accessibility": "1.0.0",
+    "com.unity.modules.adaptiveperformance": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",
     "com.unity.modules.assetbundle": "1.0.0",
     "com.unity.modules.audio": "1.0.0",
@@ -40,6 +45,7 @@
     "com.unity.modules.unitywebrequestassetbundle": "1.0.0",
     "com.unity.modules.unitywebrequestaudio": "1.0.0",
     "com.unity.modules.unitywebrequesttexture": "1.0.0",
-    "com.unity.modules.unitywebrequestwww": "1.0.0"
+    "com.unity.modules.unitywebrequestwww": "1.0.0",
+    "com.unity.modules.vectorgraphics": "1.0.0"
   }
 }

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -58,6 +58,15 @@
       "dependencies": {},
       "hash": "0213e70db84321e582d7b1406ec86f4bc68fa252"
     },
+    "com.github.kou-yeung": {
+      "version": "https://github.com/kou-yeung/WebGLInput.git?path=Assets/WebGLSupport#1.4.5",
+      "depth": 0,
+      "source": "git",
+      "dependencies": {
+        "com.unity.ugui": "1.0.0~"
+      },
+      "hash": "efe3db0a2bc3da47c5cdd1da76bd971aab726171"
+    },
     "com.unity.ai.inference": {
       "version": "2.5.0",
       "depth": 0,
@@ -72,7 +81,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.burst": {
-      "version": "1.8.24",
+      "version": "1.8.28",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -82,19 +91,20 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.collections": {
-      "version": "2.5.1",
+      "version": "2.6.2",
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.burst": "1.8.17",
-        "com.unity.test-framework": "1.4.5",
-        "com.unity.nuget.mono-cecil": "1.11.4",
+        "com.unity.burst": "1.8.23",
+        "com.unity.mathematics": "1.3.2",
+        "com.unity.test-framework": "1.4.6",
+        "com.unity.nuget.mono-cecil": "1.11.5",
         "com.unity.test-framework.performance": "3.0.3"
       },
       "url": "https://packages.unity.com"
     },
     "com.unity.dt.app-ui": {
-      "version": "1.3.3",
+      "version": "2.1.1",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -112,16 +122,16 @@
       "dependencies": {}
     },
     "com.unity.ide.visualstudio": {
-      "version": "2.0.25",
+      "version": "2.0.26",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.test-framework": "1.1.31"
+        "com.unity.test-framework": "1.1.33"
       },
       "url": "https://packages.unity.com"
     },
     "com.unity.inputsystem": {
-      "version": "1.14.2",
+      "version": "1.19.0",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -130,21 +140,21 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.mathematics": {
-      "version": "1.3.2",
+      "version": "1.3.3",
       "depth": 2,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
     "com.unity.mobile.android-logcat": {
-      "version": "1.4.6",
+      "version": "1.4.7",
       "depth": 0,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
     "com.unity.nuget.mono-cecil": {
-      "version": "1.11.4",
+      "version": "1.11.6",
       "depth": 2,
       "source": "registry",
       "dependencies": {},
@@ -158,14 +168,14 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.settings-manager": {
-      "version": "2.1.0",
+      "version": "2.1.1",
       "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.5.1",
+      "version": "1.6.0",
       "depth": 0,
       "source": "builtin",
       "dependencies": {
@@ -175,7 +185,7 @@
       }
     },
     "com.unity.test-framework.performance": {
-      "version": "3.1.0",
+      "version": "3.2.0",
       "depth": 2,
       "source": "registry",
       "dependencies": {
@@ -185,12 +195,12 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.testtools.codecoverage": {
-      "version": "1.2.7",
+      "version": "1.3.0",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.test-framework": "1.0.16",
-        "com.unity.settings-manager": "1.0.1"
+        "com.unity.test-framework": "1.4.5",
+        "com.unity.settings-manager": "2.0.0"
       },
       "url": "https://packages.unity.com"
     },
@@ -204,11 +214,12 @@
       }
     },
     "io.github.hatayama.uloopmcp": {
-      "version": "0.50.0",
+      "version": "2.1.8",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.nuget.newtonsoft-json": "3.2.1"
+        "com.unity.nuget.newtonsoft-json": "3.2.1",
+        "com.unity.ugui": "1.0.0"
       },
       "url": "https://package.openupm.com"
     },
@@ -331,6 +342,14 @@
       "source": "builtin",
       "dependencies": {}
     },
+    "com.unity.modules.adaptiveperformance": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.subsystems": "1.0.0"
+      }
+    },
     "com.unity.modules.androidjni": {
       "version": "1.0.0",
       "depth": 0,
@@ -390,7 +409,7 @@
     },
     "com.unity.modules.physics": {
       "version": "1.0.0",
-      "depth": 2,
+      "depth": 1,
       "source": "builtin",
       "dependencies": {}
     },
@@ -400,6 +419,14 @@
       "source": "builtin",
       "dependencies": {
         "com.unity.modules.imageconversion": "1.0.0"
+      }
+    },
+    "com.unity.modules.subsystems": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.jsonserialize": "1.0.0"
       }
     },
     "com.unity.modules.ui": {
@@ -416,7 +443,8 @@
         "com.unity.modules.ui": "1.0.0",
         "com.unity.modules.imgui": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0",
-        "com.unity.modules.hierarchycore": "1.0.0"
+        "com.unity.modules.hierarchycore": "1.0.0",
+        "com.unity.modules.physics": "1.0.0"
       }
     },
     "com.unity.modules.unitywebrequest": {
@@ -463,6 +491,16 @@
         "com.unity.modules.audio": "1.0.0",
         "com.unity.modules.assetbundle": "1.0.0",
         "com.unity.modules.imageconversion": "1.0.0"
+      }
+    },
+    "com.unity.modules.vectorgraphics": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.uielements": "1.0.0",
+        "com.unity.modules.imageconversion": "1.0.0",
+        "com.unity.modules.imgui": "1.0.0"
       }
     }
   }

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -9,5 +9,6 @@ EditorBuildSettings:
     path: Assets/uPiper/Scenes/InferenceEngineDemo.unity
     guid: 42f763f68be95459baf75cfe448b13e4
   m_configObjects:
+    com.unity.dt.app-ui: {fileID: 11400000, guid: 1b1c20d82303e4b5781c3ef50ac1449f, type: 2}
     com.unity.input.settings.actions: {fileID: -944628639613478452, guid: 2bcd2660ca9b64942af0de543d8d7100, type: 3}
   m_UseUCBPForAssetBundles: 0

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -70,6 +70,7 @@ PlayerSettings:
   androidStartInFullscreen: 1
   androidRenderOutsideSafeArea: 1
   androidUseSwappy: 1
+  androidDisplayOptions: 1
   androidBlitType: 0
   androidResizeableActivity: 1
   androidDefaultWindowWidth: 1920
@@ -113,6 +114,7 @@ PlayerSettings:
   xboxEnableGuest: 0
   xboxEnablePIXSampling: 0
   metalFramebufferOnly: 0
+  metalUseMetalDisplayLink: 0
   xboxOneResolution: 0
   xboxOneSResolution: 0
   xboxOneXResolution: 3
@@ -133,6 +135,7 @@ PlayerSettings:
   switchNVNMaxPublicSamplerIDCount: 0
   switchMaxWorkerMultiple: 8
   switchNVNGraphicsFirmwareMemory: 32
+  switchGraphicsJobsSyncAfterKick: 1
   vulkanNumSwapchainBuffers: 3
   vulkanEnableSetSRGBWrite: 0
   vulkanEnablePreTransform: 0
@@ -178,6 +181,7 @@ PlayerSettings:
   AndroidMinSdkVersion: 28
   AndroidTargetSdkVersion: 0
   AndroidPreferredInstallLocation: 1
+  AndroidPreferredDataLocation: 1
   aotOptions: 
   stripEngineCode: 1
   iPhoneStrippingLevel: 0
@@ -192,11 +196,11 @@ PlayerSettings:
   VertexChannelCompressionMask: 4054
   iPhoneSdkVersion: 988
   iOSSimulatorArchitecture: 0
-  iOSTargetOSVersionString: 13.0
+  iOSTargetOSVersionString: 15.0
   tvOSSdkVersion: 0
   tvOSSimulatorArchitecture: 0
   tvOSRequireExtendedGameController: 0
-  tvOSTargetOSVersionString: 13.0
+  tvOSTargetOSVersionString: 15.0
   VisionOSSdkVersion: 0
   VisionOSTargetOSVersionString: 1.0
   uIPrerenderedIcon: 0
@@ -266,6 +270,7 @@ PlayerSettings:
   useCustomGradleSettingsTemplate: 0
   useCustomProguardFile: 0
   AndroidTargetArchitectures: 2
+  AndroidAllowedArchitectures: -1
   AndroidSplashScreenScale: 0
   androidSplashScreen: {fileID: 0}
   AndroidKeystoreName: 
@@ -488,7 +493,10 @@ PlayerSettings:
   m_BuildTargetShaderSettings: []
   m_BuildTargetGraphicsJobs: []
   m_BuildTargetGraphicsJobMode: []
-  m_BuildTargetGraphicsAPIs: []
+  m_BuildTargetGraphicsAPIs:
+  - m_BuildTarget: WindowsStandaloneSupport
+    m_APIs: 0200000012000000
+    m_Automatic: 0
   m_BuildTargetVRSettings: []
   m_DefaultShaderChunkSizeInMB: 16
   m_DefaultShaderChunkCount: 0
@@ -523,7 +531,7 @@ PlayerSettings:
   locationUsageDescription: 
   microphoneUsageDescription: This app uses the microphone for voice input features.
   bluetoothUsageDescription: 
-  macOSTargetOSVersion: 11.0
+  macOSTargetOSVersion: 12.0
   switchNMETAOverride: 
   switchNetLibKey: 
   switchSocketMemoryPoolSize: 6144
@@ -771,16 +779,16 @@ PlayerSettings:
   webGLMemoryLinearGrowthStep: 16
   webGLMemoryGeometricGrowthStep: 0.2
   webGLMemoryGeometricGrowthCap: 96
-  webGLEnableWebGPU: 1
   webGLPowerPreference: 2
   webGLWebAssemblyTable: 0
   webGLWebAssemblyBigInt: 0
   webGLCloseOnQuit: 0
   webWasm2023: 0
+  webEnableSubmoduleStrippingCompatibility: 0
   scriptingDefineSymbols:
     Android: UPIPER_DEVELOPMENT;ULOOPMCP_HAS_ROSLYN
     Standalone: UPIPER_DEVELOPMENT;ULOOPMCP_HAS_ROSLYN
-    WebGL: UPIPER_DEVELOPMENT;ULOOPMCP_HAS_ROSLYN
+    WebGL: UPIPER_DEVELOPMENT;ULOOPMCP_HAS_ROSLYN;APP_UI_EDITOR_ONLY
   additionalCompilerArguments: {}
   platformArchitecture:
     iPhone: 1
@@ -908,3 +916,6 @@ PlayerSettings:
   insecureHttpOption: 0
   androidVulkanDenyFilterList: []
   androidVulkanAllowFilterList: []
+  androidVulkanDeviceFilterListAsset: {fileID: 0}
+  d3d12DeviceFilterListAsset: {fileID: 0}
+  allowedHttpConnections: 3

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 6000.0.58f2
-m_EditorVersionWithRevision: 6000.0.58f2 (92dee566b325)
+m_EditorVersion: 6000.3.11f1
+m_EditorVersionWithRevision: 6000.3.11f1 (3000ef702840)

--- a/README.en.md
+++ b/README.en.md
@@ -54,7 +54,7 @@ A Unity plugin for [piper-plus](https://github.com/ayutaz/piper-plus) - High-qua
 | multilingual-test-medium | Multilingual (ja/en/zh/es/fr/pt) | Yes | 6-language multilingual model (Prosody-enabled) |
 
 ## Requirements
-* Unity 6000.0.58f2
+* Unity 6000.3.11f1
 * Unity AI Inference Engine (com.unity.ai.inference) 2.5.0
 * C# 10.0 (LangVersion 10.0 specified in csc.rsp)
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@
 | multilingual-test-medium | 多言語(6言語: ja/en/zh/es/fr/pt) | Yes | 多言語対応モデル（Prosody対応） |
 
 ## Requirements
-* Unity 6000.0.58f2
+* Unity 6000.3.11f1
 * Unity AI Inference Engine (com.unity.ai.inference) 2.5.0
 * C# 10.0（csc.rsp で LangVersion 10.0 を指定）
 

--- a/docs/development/CI_CD_GUIDE.md
+++ b/docs/development/CI_CD_GUIDE.md
@@ -11,7 +11,7 @@ uPiperプロジェクトでは、GitHub Actionsを使用して継続的インテ
 
 **特徴**:
 - Windows/Linux/macOS/WebGL向けビルド
-- Unity 6000.0.58f2使用
+- Unity 6000.3.11f1使用
 - Mono2x/IL2CPPバックエンド対応
 - 自動リリース作成（タグプッシュ時）
 - `.unitypackage`自動エクスポート・リリース添付（タグプッシュ時）

--- a/docs/platforms/webgl/JAPANESE_INPUT.md
+++ b/docs/platforms/webgl/JAPANESE_INPUT.md
@@ -44,7 +44,7 @@ TMP_InputField（Unity 側）
 | パッケージ名 | `com.github.kou-yeung` |
 | namespace | `WebGLSupport` |
 | パッケージサイズ | 18KB |
-| Unity 要件 | 2023.2+（uPiper: 6000.0.58f2 で互換性あり） |
+| Unity 要件 | 2023.2+（uPiper: 6000.3.11f1 で互換性あり） |
 | 依存パッケージ | `com.unity.ugui: 1.0.0~` のみ（uPiper で導入済み） |
 | TMP_InputField 対応 | あり（`WrappedTMPInputField`、Unity 2018.2+ で自動有効） |
 

--- a/docs/platforms/webgl/tickets/T-004-cicd-pipeline.md
+++ b/docs/platforms/webgl/tickets/T-004-cicd-pipeline.md
@@ -29,7 +29,7 @@ WebGLInputはpublicなGitリポジトリからのUPM Git URL参照（`https://gi
 - EditModeテスト全件パス確認
 - WebGLInputパッケージの追加がテスト実行に影響しないことを確認
 - トリガー: branches: main, develop
-- Unity: 6000.0.58f2
+- Unity: 6000.3.11f1
 
 #### 2. unity-build.yml — マルチプラットフォームビルド
 


### PR DESCRIPTION
## 概要

Unity Editor を **6000.0.58f2 → 6000.3.11f1** にアップグレードし、関連するパッケージ更新（uLoopMCP 2.1.8 含む）と CIワークフローの版数更新をまとめたPR。

先行PR #183（ツーリング整備）から**意図的に分離**したもの。#183 ではこのアップグレードが CI（6000.0.58f2 ハードコード）と不整合で全ジョブを落としたため切り出し、本PRで **CIワークフロー側の版数も同時に更新**して整合させている。

## 変更内容

### プロジェクト本体
- `ProjectSettings/ProjectVersion.txt`: 6000.0.58f2 → **6000.3.11f1**
- `Packages/manifest.json` / `packages-lock.json`:
  - `io.github.hatayama.uloopmcp` 0.50.0 → **2.1.8**
  - `com.unity.inputsystem` 1.14.2 → 1.19.0、`com.unity.test-framework` 1.5.1 → 1.6.0、`com.unity.ide.visualstudio` 2.0.25 → 2.0.26、`com.unity.testtools.codecoverage` 1.2.7 → 1.3.0、`com.unity.mobile.android-logcat` 1.4.6 → 1.4.7
  - `com.github.kou-yeung`（WebGLInput）追加
  - `com.unity.ai.inference` 等の依存解決を 6000.3.11f1 で再生成
- `ProjectSettings/ProjectSettings.asset` / `EditorBuildSettings.asset`: 6000.3.11f1 で再保存

### CI / ドキュメント
- 全ワークフローの `unityVersion` を **6000.3.11f1** に更新（unity-tests / unity-build×3 / unity-build-matrix / unity-il2cpp-build / deploy-webgl）
  - **game-ci の `unityci/editor:*-6000.3.11f1-*-3` イメージ存在を確認済み**（base/linux-il2cpp/webgl/mac-mono/windows-mono/android）
- README / README.en / Assets/uPiper/README / CI_CD_GUIDE / JAPANESE_INPUT / T-004 の Unity 版数表記を更新
- CHANGELOG に Changed エントリ追加

## 補足
- `Samples~/BasicTTSDemo/*.md` の版数表記は本PRでは未更新（pre-commit の .meta ガードが Samples~ 配下を誤検知するため。別途ガード側に Samples~ 除外を入れてから対応予定）

🤖 Generated with [Claude Code](https://claude.ai/code)
